### PR TITLE
Fix errors and warnings when building for Swift 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See [tags/releases](https://github.com/smart-on-fhir/Swift-FHIR/releases).
 
  Version |   Swift   |      FHIR     | &nbsp;
 ---------|-----------|---------------|-----------------------------
+  **3.1**|       3.2 | `3.0.0.11832` | STU 3
  **3.0** |       3.0 | `3.0.0.11832` | STU 3
 **2.10** |       3.0 | `1.8.0.10521` | STU 3 Freeze, Jan 2017
  **2.9** |       3.0 |  `1.6.0.9663` | STU 3 Ballot, Sep 2016

--- a/Sources/Client/Element+Extensions.swift
+++ b/Sources/Client/Element+Extensions.swift
@@ -19,7 +19,7 @@ public extension FHIRPrimitive {
 	
 	- parameter forURI: The URI defining the extension on the receiver
 	*/
-	public final func extensions(forURI uri: String) -> [Extension]? {
+	public func extensions(forURI uri: String) -> [Extension]? {
 		return extension_fhir?.filter() { return $0.url?.absoluteString == uri }
 	}
 }

--- a/Sources/Models/DateAndTime.swift
+++ b/Sources/Models/DateAndTime.swift
@@ -12,7 +12,7 @@ import Foundation
 /**
 A protocol for all our date and time structs.
 */
-protocol DateAndTime: FHIRPrimitive, CustomStringConvertible, Comparable, Equatable {
+protocol DateAndTime: FHIRPrimitive, CustomStringConvertible, Comparable {
 	
 	var nsDate: Date { get }
 	
@@ -340,9 +340,9 @@ public struct FHIRTime: DateAndTime {
 		}
 		if let s = second {
 			#if os(Linux)
-			return String(format: "%02d:%02d:", hour, minute) + ((s < 10) ? "0" : "") + String(format: "%g", s)
+			return String(format: "%02d:%02d:", hour, minute) + ((s < 10.0) ? "0" : "") + String(format: "%g", s)
 			#else
-			return String(format: "%02d:%02d:%@%g", hour, minute, (s < 10) ? "0" : "", s)
+			return String(format: "%02d:%02d:%@%g", hour, minute, (s < 10.0) ? "0" : "", s)
 			#endif
 		}
 		return String(format: "%02d:%02d", hour, minute)

--- a/Sources/Models/FHIRType.swift
+++ b/Sources/Models/FHIRType.swift
@@ -112,7 +112,7 @@ extension FHIRJSONType {
 	- parameter json:    The JSON element to use to populate the receiver
 	- parameter context: An in-out parameter being filled with key names used.
 	*/
-	public final func populateAndFinalize(from json: FHIRJSON, context: inout FHIRInstantiationContext) {
+	public func populateAndFinalize(from json: FHIRJSON, context: inout FHIRInstantiationContext) {
 		context.insertKey("fhir_comments")
 		populate(from: json, context: &context)
 		


### PR DESCRIPTION
This commit fixes 
- Errors thrown in `DateAndTime.swift` when trying to build for Swift 3.2 (xCode 9).
- Warnings shown when trying to build for Swift 3.2 (xCode 9).
