### PR TITLE
Update for Swift package manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## 4.2
+
+- Update Swift 5.0 package manifest.
+
 ## 4.1
 
 - Update to Swift 5.0

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,36 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 //  Package.swift
 //  SwiftFHIR
 //
 //  Created by Pascal Pfiffner on 12/10/15.
-//  2015, SMART Platforms.
+//  Modified by Dave Carlson on 8/6/2019.
 //
 
 import PackageDescription
 
 let package = Package(
-	name: "SwiftFHIR",
-	targets: [
-		Target(name: "Models"),
-		Target(name: "Client", dependencies: [.Target(name: "Models")]),
-	]
+	name: "FHIR",
+	platforms: [
+		.macOS(.v10_13), .iOS(.v11)
+	],
+    products: [
+        .library(
+            name: "FHIR",
+            targets: ["FHIR"]),
+    ],
+    targets: [
+		.target(
+			name: "FHIR",
+			dependencies: ["Models", "Client"]),
+		.target(
+			name: "Models",
+			dependencies: []),
+		.target(
+			name: "Client",
+			dependencies: ["Models"]),
+		
+		// Test targets not supported until Swift Packages include resource bundles.
+    ]
 )

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See [tags/releases](https://github.com/smart-on-fhir/Swift-FHIR/releases).
 
  Version |   Swift   |      FHIR     | &nbsp;
 ---------|-----------|---------------|-----------------------------
+**4.2**|       5.0 Packages | `4.0.0-a53ec6ee1b` | R4
 **4.1**|       5.0 | `4.0.0-a53ec6ee1b` | R4
 **4.0**|       4.2 | `4.0.0-a53ec6ee1b` | R4
   **3.1**|       3.2 | `3.0.0.11832` | STU 3

--- a/Sources/Client/FHIRBaseRequestHandler.swift
+++ b/Sources/Client/FHIRBaseRequestHandler.swift
@@ -170,7 +170,7 @@ open class FHIRDataRequestHandler: FHIRBaseRequestHandler {
 	
 	public let contentType: String
 	
-	init(_ method: FHIRRequestMethod, contentType: String) {
+	public init(_ method: FHIRRequestMethod, contentType: String) {
 		self.contentType = contentType
 		super.init(method, resource: nil)
 	}

--- a/Sources/Client/FHIRMinimalServer.swift
+++ b/Sources/Client/FHIRMinimalServer.swift
@@ -26,7 +26,7 @@ open class FHIRMinimalServer: FHIRServer {
 	public final let baseURL: URL
 	
 	/// The active URL session.
-	var session: URLSession?
+	public var session: URLSession?
 	
 	
 	/**
@@ -154,7 +154,7 @@ open class FHIRMinimalServer: FHIRServer {
 		return Foundation.URLSession.shared
 	}
 	
-	func abortSession() {
+	public func abortSession() {
 		if nil != session {
 			session!.invalidateAndCancel()
 			session = nil

--- a/Sources/Client/FHIROpenServer.swift
+++ b/Sources/Client/FHIROpenServer.swift
@@ -68,7 +68,7 @@ open class FHIROpenServer: FHIRMinimalServer {
 	Executes a `read` action against the server's "metadata" path, as returned from `cababilityStatementPath()`, which should return the
 	cabability statement.
 	*/
-	final func getCapabilityStatement(_ callback: @escaping (_ error: FHIRError?) -> ()) {
+	public final func getCapabilityStatement(_ callback: @escaping (_ error: FHIRError?) -> ()) {
 		if nil != cabability {
 			callback(nil)
 			return

--- a/Sources/FHIR/SwiftFHIR.swift
+++ b/Sources/FHIR/SwiftFHIR.swift
@@ -1,0 +1,10 @@
+//
+//  SwiftFHIR.swift
+//  SwiftFHIR
+//
+//  Created by Dave Carlson on 8/7/19.
+//  Copyright © 2019 SMART Health IT. All rights reserved.
+//
+
+@_exported import Models
+@_exported import Client

--- a/SwiftFHIR.xcodeproj/project.pbxproj
+++ b/SwiftFHIR.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		B47BEB61221E336A00929C5D /* SubstanceSpecification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47BEADB221E32AB00929C5D /* SubstanceSpecification.swift */; };
 		B47BEB62221E336A00929C5D /* TerminologyCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47BEADD221E32AB00929C5D /* TerminologyCapabilities.swift */; };
 		B47BEB63221E336A00929C5D /* VerificationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47BEAEF221E32AD00929C5D /* VerificationResult.swift */; };
+		B4BDC66422FDADFA00CE4B72 /* SwiftFHIR.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4BDC66322FDADFA00CE4B72 /* SwiftFHIR.swift */; };
 		B4FA8C23221F025700BD72A1 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47BEAEB221E32AC00929C5D /* Expression.swift */; };
 		B4FA8C24221F025700BD72A1 /* ParameterDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6C88C21CB39A6A00ADFF94 /* ParameterDefinition.swift */; };
 		B4FA8C25221F025700BD72A1 /* UsageContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE31DC691D64AC6200B04BEA /* UsageContext.swift */; };
@@ -982,6 +983,7 @@
 		B47BEB01221E32AF00929C5D /* SubstanceAmount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubstanceAmount.swift; sourceTree = "<group>"; };
 		B47BEB02221E32AF00929C5D /* MedicinalProductIngredient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MedicinalProductIngredient.swift; sourceTree = "<group>"; };
 		B47BEB03221E32AF00929C5D /* OrganizationAffiliation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrganizationAffiliation.swift; sourceTree = "<group>"; };
+		B4BDC66322FDADFA00CE4B72 /* SwiftFHIR.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftFHIR.swift; sourceTree = "<group>"; };
 		EE01F96F1C58F6AB003AEA7E /* DomainResource+Containment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DomainResource+Containment.swift"; sourceTree = "<group>"; };
 		EE01F9721C58FC51003AEA7E /* ResourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourceTests.swift; sourceTree = "<group>"; };
 		EE02F5911ACF252000179969 /* Address.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
@@ -1327,6 +1329,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B4BDC66222FDADFA00CE4B72 /* FHIR */ = {
+			isa = PBXGroup;
+			children = (
+				B4BDC66322FDADFA00CE4B72 /* SwiftFHIR.swift */,
+			);
+			name = FHIR;
+			path = Sources/FHIR;
+			sourceTree = "<group>";
+		};
 		EE684C1419A789BA00B5A2C0 = {
 			isa = PBXGroup;
 			children = (
@@ -1354,6 +1365,7 @@
 		EE684C2019A789BA00B5A2C0 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				B4BDC66222FDADFA00CE4B72 /* FHIR */,
 				EE9B31F61ACAD94800980AA9 /* Client */,
 				EE684C4219A78AEE00B5A2C0 /* Models */,
 			);
@@ -2008,6 +2020,7 @@
 				EE6C88CA1CB39A6A00ADFF94 /* CareTeam.swift in Sources */,
 				B47BEB22221E32AF00929C5D /* EffectEvidenceSynthesis.swift in Sources */,
 				B47BEB1A221E32AF00929C5D /* Population.swift in Sources */,
+				B4BDC66422FDADFA00CE4B72 /* SwiftFHIR.swift in Sources */,
 				EE02F68F1ACF252000179969 /* MessageHeader.swift in Sources */,
 				EE02F6231ACF252000179969 /* CodeableConcept.swift in Sources */,
 				EE02F69F1ACF252000179969 /* OperationOutcome.swift in Sources */,


### PR DESCRIPTION
Update Swift package manifest, will be integrated into Swift-SMART using Swift Package Manager (SPM) dependency.

Several functions modified to 'public' visibility for use by Swift-SMART.  With SPM dependency, this module is now imported as a package instead of copying all sources into the SMART project build, which surfaced these issues with package visibility.