### PR TITLE
Fixed issue where summary version of the capability statement is fetched

### DIFF
--- a/Sources/Client/FHIROpenServer.swift
+++ b/Sources/Client/FHIROpenServer.swift
@@ -68,14 +68,14 @@ open class FHIROpenServer: FHIRMinimalServer {
 	Executes a `read` action against the server's "metadata" path, as returned from `cababilityStatementPath()`, which should return the
 	cabability statement.
 	*/
-	public final func getCapabilityStatement(_ callback: @escaping (_ error: FHIRError?) -> ()) {
+    public final func getCapabilityStatement(options: FHIRRequestOption = [.lenient], _ callback: @escaping (_ error: FHIRError?) -> ()) {
 		if nil != cabability {
 			callback(nil)
 			return
 		}
 		
 		// not yet fetched, fetch it
-		CapabilityStatement.readFrom("metadata", server: self, options: [.summary, .lenient]) { resource, error in
+		CapabilityStatement.readFrom("metadata", server: self, options: options) { resource, error in
 			if let conf = resource as? CapabilityStatement {
 				self.cabability = conf
 				callback(nil)


### PR DESCRIPTION
Fix for Issue #26  

This PR fixes an issue where the Swift-FHIR Library only fetches a summary version of the Capability Statement. Because SMART on FHIR authorization endpoints are included in an extension in the Capability Statement, some FHIR servers will not include the endpoints in summary requests.